### PR TITLE
Fix #1: get() before put() fails drain()

### DIFF
--- a/lib/Promises/Channel.pm
+++ b/lib/Promises/Channel.pm
@@ -149,7 +149,6 @@ sub put {
   my $soon = deferred;
 
   my $promise = $soon->promise->then(sub {
-    my ($self, $item) = @_;
     $self->drain;
     return $self;
   });


### PR DESCRIPTION
Remove processing of arguments in `put()`'s `$soon` promise:
the `$self` variable shadows the one from the outer scope *and*
(more importantly) the promise doesn't resolve to `$self` but
to `$self->size`.
By consequence, `$self->drain` can't be called because `$self`
doesn't refer to the channel instance with the parameter
handling in place.
Hence removing.